### PR TITLE
Fix callback exceptions

### DIFF
--- a/lib/active_record/journal/journable/context.rb
+++ b/lib/active_record/journal/journable/context.rb
@@ -52,6 +52,7 @@ module ActiveRecord
           ActiveRecord::Journal.context_override = nil
         rescue StandardError
           ActiveRecord::Journal.context_override = nil
+          raise
         end
 
         def ignore_actions

--- a/spec/features/added_conditions_spec.rb
+++ b/spec/features/added_conditions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'configuration override' do
+RSpec.describe 'added conditions' do
   let(:context) { klass.journable_context }
   let(:journal_records) { configuration.entries_class }
   let(:configuration) { ActiveRecord::Journal.configuration }
@@ -26,7 +26,7 @@ RSpec.describe 'configuration override' do
     end
 
     context 'when actions raise error' do
-      before do
+      let(:tracking) do
         record.reload
         ActiveRecord::Journal.ignore do |c|
           c.actions do
@@ -37,8 +37,13 @@ RSpec.describe 'configuration override' do
       end
 
       it 'record actions' do
-        expect(tag).to be nil
+        expect { tracking }.to raise_error StandardError
         expect(journal_records.count).to eq 1
+      end
+
+      it 'does not create tags' do
+        expect { tracking }.to raise_error StandardError
+        expect(tag).to be nil
       end
 
       it 'clears context override' do
@@ -67,7 +72,7 @@ RSpec.describe 'configuration override' do
     end
 
     context 'when actions raise error' do
-      before do
+      let(:tracking) do
         ActiveRecord::Journal.tag(description: 'test') do |context|
           context.actions do
             record
@@ -79,16 +84,18 @@ RSpec.describe 'configuration override' do
       end
 
       it 'record actions' do
+        expect { tracking }.to raise_error StandardError
         expect(journal_records.where(journal_tag_id: tag.id).count).to eq 1
       end
 
       it 'clears context override' do
+        expect { tracking }.to raise_error StandardError
         expect(ActiveRecord::Journal.context_override).to be nil
       end
     end
 
     context 'when actions raise error in transaction' do
-      before do
+      let(:tracking) do
         ActiveRecord::Journal.tag(description: 'test') do |context|
           context.actions do
             klass.transaction do
@@ -102,8 +109,13 @@ RSpec.describe 'configuration override' do
       end
 
       it 'record actions' do
-        expect(tag).to be nil
+        expect { tracking }.to raise_error StandardError
         expect(journal_records.count).to eq 0
+      end
+
+      it 'does not create tags' do
+        expect { tracking }.to raise_error StandardError
+        expect(tag).to be nil
       end
 
       it 'clears context override' do
@@ -137,7 +149,7 @@ RSpec.describe 'configuration override' do
     end
 
     context 'when actions raise error' do
-      before do
+      let(:tracking) do
         record
         ActiveRecord::Journal.context do |c|
           c.record(klass, :writes, if: ->(r) { r.last_name == 'Doe' })
@@ -152,8 +164,13 @@ RSpec.describe 'configuration override' do
       end
 
       it 'record actions' do
-        expect(tag).to be nil
+        expect { tracking }.to raise_error StandardError
         expect(journal_records.count).to eq 2
+      end
+
+      it 'does not create tags' do
+        expect { tracking }.to raise_error StandardError
+        expect(tag).to be nil
       end
 
       it 'clears context override' do

--- a/spec/features/conditioned_tracking_spec.rb
+++ b/spec/features/conditioned_tracking_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'conditioned tracking' do
     end
   end
 
-  describe 'when action is destroy' do
+  context 'when action is destroy' do
     let(:book_model) do
       Class.new(Fixtures::Anonymous) do
         self.table_name = :books
@@ -74,7 +74,7 @@ RSpec.describe 'conditioned tracking' do
     end
   end
 
-  describe 'when action is update' do
+  context 'when action is update' do
     let(:book_model) do
       Class.new(Fixtures::Anonymous) do
         self.table_name = :books


### PR DESCRIPTION
Callback exceptions were being cached and not re-raised for another layer to be able to handle or report the exception. Now the caught error is being raised again.